### PR TITLE
Removed Frame titles

### DIFF
--- a/easy_sync/lib/pages/editPage.dart
+++ b/easy_sync/lib/pages/editPage.dart
@@ -25,7 +25,7 @@ class _EditPageState extends State<EditPage> {
     }
 
     return Frame(
-      title: "Edit Page",
+      // title: "Edit Page",
       onNextPressed: () {
         Navigator.push(
             context,

--- a/easy_sync/lib/pages/inputPage.dart
+++ b/easy_sync/lib/pages/inputPage.dart
@@ -114,7 +114,7 @@ class _InputPageState extends State<InputPage> {
     };
 
     return Frame(
-      title: 'Input',
+      // title: 'Input',
       onNextPressed: () {
         if (useDefaults) {
           Navigator.push(context, MaterialPageRoute(builder: (context) => LoginPage(widget.table.getEvents(questions))));

--- a/easy_sync/lib/pages/loginPage.dart
+++ b/easy_sync/lib/pages/loginPage.dart
@@ -107,7 +107,7 @@ class _LoginPageState extends State<LoginPage> {
   @override
   Widget build(BuildContext context) {
     return Frame(
-      title: 'Login Page',
+      // title: 'Login Page',
       onNextPressed: () {
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(content: Text('No next page')),

--- a/easy_sync/lib/tools/frame.dart
+++ b/easy_sync/lib/tools/frame.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 
 class Frame extends StatefulWidget {
   final Widget child;
-  final String title;
+  final String? title;
   final VoidCallback? onNextPressed;
   final Color? nextColor;
   final Color? prevColor;
@@ -10,7 +10,7 @@ class Frame extends StatefulWidget {
 
   const Frame({
     super.key,
-    required this.title,
+    this.title,
     required this.child,
     this.onNextPressed,
     this.nextColor = Colors.blue,
@@ -26,8 +26,7 @@ class _FrameState extends State<Frame> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text(widget.title),
-  
+        title: Text(widget.title ?? ""),
       ),
       //used to display add button throughout all pages
       body: widget.child,


### PR DESCRIPTION
I removed the Frame title attribute from the pages and made it optional in the Frame widget because I don't think it looked good. Now I think it looks more clean, but if we don't like it we can just uncomment the titles