### PR TITLE
Removed appbar from Frame

### DIFF
--- a/easy_sync/lib/tools/frame.dart
+++ b/easy_sync/lib/tools/frame.dart
@@ -25,9 +25,9 @@ class _FrameState extends State<Frame> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: Text(widget.title ?? ""),
-      ),
+      // appBar: AppBar(
+      //   title: Text(widget.title ?? ""),
+      // ),
       //used to display add button throughout all pages
       body: widget.child,
       bottomNavigationBar: Column(


### PR DESCRIPTION
I removed the appbar from the Frame entirely (Just commented out for now). It looks more clean now and we don't have a redundant back arrow, but now it looks kind of plain so we might want to change it